### PR TITLE
More dependencies

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -6,3 +6,8 @@ lib_deps =
     s00500/ESPUI@^2.1.1
     waspinator/AccelStepper@^1.61
     crankyoldgit/IRremoteESP8266@^2.8.2
+    lorol/LittleFS_esp32@^1.0.6
+    bblanchon/ArduinoJson@^6.19.4
+    esphome/ESPAsyncWebServer-esphome@^2.1.0
+    me-no-dev/AsyncTCP@1.1.1
+    me-no-dev/ESP Async WebServer@^1.1.1


### PR DESCRIPTION
The latest version of P.io seems to need these now.

The littelfs also creates and error and the file needs to be edited after "r" you need to add ",false". Shown here, https://github.com/lorol/LITTLEFS/issues/43

No need to merge these, I hope that bug gets fixed, just keeping notes. Thanks!